### PR TITLE
[travis] install table_version 1.3.0 from github

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,11 @@ before_install:
   - sudo env "PATH=$PATH" make install
   - cd ..
   # Install postgresql-tableversion
-  - sudo env "PATH=$PATH" pgxn install table_version || true # workaround table_version bug in version 1.1.1, see https://github.com/linz/postgresql-tableversion/pull/31
+  - wget https://github.com/linz/postgresql-tableversion/archive/1.3.0.tar.gz
+  - tar xzf 1.3.0.tar.gz && cd postgresql-tableversion-1.3.0
+  - make
+  - sudo env "PATH=$PATH" make install
+  - cd ..
 script:
   - make
   - make check || { cat regression.diffs; false; }


### PR DESCRIPTION
Drops testing of the 1.1.1 version (and use of
the PGXS install system)