### PR TITLE
Add support for LDSBDESCHEMA_SQLDIR env variable in loader

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ REVISION=$(shell test -d .git && which git > /dev/null && git describe --always)
 SED = sed
 
 datadir=${DESTDIR}/usr/share/linz-lds-bde-schema
-bindir=${DESTDIR}/usr/local/bin
+bindir=${DESTDIR}/usr/bin
 
 #
 # Uncoment these line to support testing via pg_regress

--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ to the `linz-bde-schema-load` invocation:
 
 ```shell
 linz-lds-bde-schema-load --revision $DB_NAME
+
+NOTE: the loader script will expect to find SQL scripts
+      under `/usr/share/linz-lds-bde-schema/sql`, if you want
+      them found in a different directory you can set the
+      ``LDSBDESCHEMA_SQLDIR`` environment variable.
 ```
 
 Upgrade

--- a/scripts/linz-lds-bde-schema-load
+++ b/scripts/linz-lds-bde-schema-load
@@ -5,6 +5,10 @@ export SKIP_INDEXES=no
 export PSQL=psql
 export SCRIPTSDIR=/usr/share/linz-bde-schema/sql/
 
+if test -n "${LDSBDESCHEMA_SQLDIR}"; then
+    SCRIPTSDIR=${LDSBDESCHEMA_SQLDIR}
+fi
+
 while test -n "$1"; do
     if test $1 = "--noindexes"; then
         SKIP_INDEXES=yes


### PR DESCRIPTION
And install linz-lds-bde-schema-load in /usr/bin,
not /usr/local/bin