### PR TITLE
Tweak tmp_parcels creation function to avoid nested function call

### DIFF
--- a/sql/04-lds_layer_functions.sql.in
+++ b/sql/04-lds_layer_functions.sql.in
@@ -1844,8 +1844,9 @@ BEGIN
 
     CREATE TEMP TABLE tmp_parcels AS
     SELECT
+        DISTINCT ON (PAR.id)
         PAR.id,
-        bde_get_combined_appellation(PAR.id, 'N') AS appellation,
+        bde_get_app_specific(APP, 'N') AS appellation,
         string_agg(
             DISTINCT
                 SUR.survey_reference,
@@ -1869,6 +1870,7 @@ BEGIN
     FROM
         tmp_world_regions WDR,
         crs_parcel PAR
+        LEFT JOIN crs_appellation APP ON PAR.id = APP.par_id AND APP.status = 'CURR'
         JOIN tmp_parcel_geoms GEOM ON PAR.id = GEOM.par_id
         JOIN crs_locality LOC ON PAR.ldt_loc_id = LOC.id
         LEFT JOIN tmp_title_parcel_associations TTL ON PAR.id = TTL.par_id
@@ -1879,9 +1881,9 @@ BEGIN
         PAR.status IN ('CURR', 'HIST', 'APPR', 'SHST', 'PEND') AND
         (ST_Contains(WDR.shape, PAR.shape) OR PAR.shape IS NULL)
     GROUP BY
-        1, 2, 4, 5, 6, 7, 8, 10, 11, 12
+        1, 2, 4, 5, 6, 7, 8, 10, 11, 12, APP.survey, APP.title
     ORDER BY
-        PAR.id;
+        PAR.id, APP.survey, APP.title;
 
     RAISE INFO 'Finished creating temp table tmp_parcels';
 


### PR DESCRIPTION
Avoids calling a function for each and every record in crs_parcels.

Depends on linz-bde-schema version 1.1.0 or higher for the
availability of the `bde_get_app_specific` function taking
`crs_appellation` record.

For a crs_parcels with 4million records it was observed a time
reduction from 14 minutes to 10 minutes.

References #30