### PR TITLE
Add additonal hydro parcel intent codes

### DIFF
--- a/sql/04-lds_layer_functions.sql.in
+++ b/sql/04-lds_layer_functions.sql.in
@@ -2125,7 +2125,7 @@ BEGIN
         WHERE
             PAR.status = 'CURR' AND
             PAR.toc_code =  'PRIM' AND
-            PAR.parcel_intent NOT IN ('HYDR', 'ROAD') AND
+            PAR.parcel_intent NOT IN ('HYDR', 'VCMC', 'VDCO', 'VDLA', 'ROAD') AND
             ST_GeometryType(PAR.shape) IN ('ST_MultiPolygon', 'ST_Polygon');
     $sql$;
 
@@ -2174,7 +2174,7 @@ BEGIN
         WHERE
             PAR.status = 'CURR' AND
             PAR.toc_code =  'PRIM' AND
-            PAR.parcel_intent = 'HYDR' AND
+            PAR.parcel_intent IN ('HYDR', 'VCMC', 'VDCO', 'VDLA') AND
             ST_GeometryType(PAR.shape) IN ('ST_MultiPolygon', 'ST_Polygon');
     $sql$;
 


### PR DESCRIPTION
Property Rights confirmed hydro parcels are identified by all of the following parcel intents: 'HYDR', 'VCMC', 'VDCO', 'VDLA'.
Have run a query in Postgresql and confirmed parcels with 'VCMC', 'VDCO', 'VDLA' parcel intents are in river and marine areas. There isn't very many of them which is why we hadn't noticed before.