### PR TITLE
Drop explicit binary package dependency on PostgreSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,8 @@ Dependencies
 ------------
 
 Requires [linz-bde-schema](https://github.com/linz/linz-bde-schema) (v1.1.0+),
-[table_version](https://github.com/linz/postgresql-tableversion),
-[linz-postgresql-functions](https://github.com/linz/linz-postgresql-functions)
-and [linz_bde_uploader](https://github.com/linz/linz_bde_uploader) packages
+and [table_version](https://github.com/linz/postgresql-tableversion) (v1.4.0+)
+packages
 
 License
 ---------------------

--- a/debian/control
+++ b/debian/control
@@ -12,10 +12,8 @@ Vcs-Browser: https://github.com/linz/linz-lds-bde-schema.git
 Package: linz-lds-bde-schema
 Architecture: all
 Depends: ${misc:Depends},
-         postgresql-contrib-9.3,
-         postgresql-9.3-dbpatch,
+         postgresql-9.3-tableversion (>= 1.4.0),
          linz-postgresql-9.3-functions,
          linz-bde-schema
-Recommends: postgresql-9.3-tableversion
 Description: Provides the schemas and functions to generate the Landonline
  layers and tables that are available on the LDS.

--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,6 @@ Package: linz-lds-bde-schema
 Architecture: all
 Depends: ${misc:Depends},
          postgresql-9.3-tableversion (>= 1.4.0),
-         linz-postgresql-9.3-functions,
          linz-bde-schema
 Description: Provides the schemas and functions to generate the Landonline
  layers and tables that are available on the LDS.

--- a/debian/control
+++ b/debian/control
@@ -12,9 +12,7 @@ Vcs-Browser: https://github.com/linz/linz-lds-bde-schema.git
 Package: linz-lds-bde-schema
 Architecture: all
 Depends: ${misc:Depends},
-         postgresql-9.3,
          postgresql-contrib-9.3,
-         postgresql-9.3-postgis-2.1|postgresql-9.3-postgis-2.2,
          postgresql-9.3-dbpatch,
          linz-postgresql-9.3-functions,
          linz-bde-schema

--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Vcs-Browser: https://github.com/linz/linz-lds-bde-schema.git
 Package: linz-lds-bde-schema
 Architecture: all
 Depends: ${misc:Depends},
-         postgresql-9.3-tableversion (>= 1.4.0),
-         linz-bde-schema
+         postgresql-9.3-tableversion (>= 1.4.0)
+Recommends: linz-bde-schema
 Description: Provides the schemas and functions to generate the Landonline
  layers and tables that are available on the LDS.


### PR DESCRIPTION
We'll need table_version-1.4.0+ for linz-lds-bde-schema-loader to find
table_version-loader, but nothing else should be a strong dependency.