### PR TITLE
Add bde_ext.ttl_inst_full table

### DIFF
--- a/sql/05-bde_ext_schema.sql
+++ b/sql/05-bde_ext_schema.sql
@@ -854,10 +854,10 @@ GRANT SELECT, UPDATE, INSERT, DELETE ON TABLE ttl_hierarchy TO bde_admin;
 GRANT SELECT ON TABLE ttl_hierarchy TO bde_user;
 
 -- =============================================================================
--- T T L   I N S T
+-- T T L   I N S T   FULL
 -- =============================================================================
-DROP TABLE IF EXISTS ttl_inst CASCADE;
-CREATE TABLE ttl_inst
+DROP TABLE IF EXISTS ttl_inst_full CASCADE;
+CREATE TABLE ttl_inst_full
 (
   id INTEGER NOT NULL,
   inst_no VARCHAR(30) NOT NULL,
@@ -870,13 +870,39 @@ CREATE TABLE ttl_inst
   priority_no INTEGER,
   tin_id_parent INTEGER,
   audit_id INTEGER NOT NULL,
-  CONSTRAINT pkey_ttl_inst PRIMARY KEY (id)
+  completion_date DATE,
+  CONSTRAINT pkey_ttl_inst_full PRIMARY KEY (id)
 );
 
-ALTER TABLE ttl_inst OWNER TO bde_dba;
-REVOKE ALL ON TABLE ttl_inst FROM PUBLIC;
-GRANT SELECT, UPDATE, INSERT, DELETE ON TABLE ttl_inst TO bde_admin;
-GRANT SELECT ON TABLE ttl_inst TO bde_user;
+ALTER TABLE ttl_inst_full OWNER TO bde_dba;
+REVOKE ALL ON TABLE ttl_inst_full FROM PUBLIC;
+GRANT SELECT, UPDATE, INSERT, DELETE ON TABLE ttl_inst_full TO bde_admin;
+GRANT SELECT ON TABLE ttl_inst_full TO bde_user;
+
+-- =============================================================================
+-- T T L   I N S T
+-- =============================================================================
+DROP TABLE IF EXISTS ttl_inst CASCADE; -- used to a table before 1.2.0
+DROP VIEW IF EXISTS ttl_inst CASCADE;
+CREATE VIEW ttl_inst AS
+SELECT
+  id,
+  inst_no,
+  trt_grp,
+  trt_type,
+  ldt_loc_id,
+  status,
+  lodged_datetime,
+  dlg_id,
+  priority_no,
+  tin_id_parent,
+  audit_id
+FROM bde_ext.ttl_inst_full;
+
+ALTER VIEW ttl_inst OWNER TO bde_dba;
+REVOKE ALL ON ttl_inst FROM PUBLIC;
+GRANT SELECT, UPDATE, INSERT, DELETE ON ttl_inst TO bde_admin;
+GRANT SELECT ON ttl_inst TO bde_user;
 
 -- =============================================================================
 -- T T L   I N S T   T I T L E

--- a/sql/06-bde_ext_functions.sql.in
+++ b/sql/06-bde_ext_functions.sql.in
@@ -123,7 +123,7 @@ BEGIN
                     'crs_transact_type',
                     'crs_ttl_enc',
                     'crs_ttl_hierarchy',
-                    'crs_ttl_inst',
+                    'crs_ttl_inst_full',
                     'crs_ttl_inst_title',
                     'crs_user',
                     'crs_vector',
@@ -175,7 +175,7 @@ BEGIN
         AND LDS.LDS_TableHasData('bde_ext', 'transact_type')
         AND LDS.LDS_TableHasData('bde_ext', 'ttl_enc')
         AND LDS.LDS_TableHasData('bde_ext', 'ttl_hierarchy')
-        AND LDS.LDS_TableHasData('bde_ext', 'ttl_inst')
+        AND LDS.LDS_TableHasData('bde_ext', 'ttl_inst_full')
         AND LDS.LDS_TableHasData('bde_ext', 'ttl_inst_title')
         AND LDS.LDS_TableHasData('bde_ext', 'user')
         AND LDS.LDS_TableHasData('bde_ext', 'vector_pt')
@@ -1988,9 +1988,9 @@ BEGIN
     );
 
     ----------------------------------------------------------------------------
-    -- ttl inst layer (2)
+    -- ttl inst full layer (2)
     ----------------------------------------------------------------------------
-    v_table := LDS.LDS_GetTable('bde_ext', 'ttl_inst');
+    v_table := LDS.LDS_GetTable('bde_ext', 'ttl_inst_full');
 
 
     v_data_insert_sql := $sql$
@@ -2005,7 +2005,8 @@ BEGIN
                 trt_grp,
                 trt_type,
                 audit_id,
-                tin_id_parent
+                tin_id_parent,
+                completion_date
         )
         SELECT
                 TIN.id,
@@ -2018,7 +2019,8 @@ BEGIN
                 TIN.trt_grp,
                 TIN.trt_type,
                 TIN.audit_id,
-                TIN.tin_id_parent
+                TIN.tin_id_parent,
+                TIN.completion_date
         FROM crs_ttl_inst TIN
         INNER JOIN (
                 SELECT tin_id FROM crs_action


### PR DESCRIPTION
This PR is alternative to #74.
It creates a bde_ext.ttl_inst_full table having all fields from
ttl_inst plus a completion_date field.

Then it turns ttl_inst into a view selecting all but completion_date
from the ttl_inst_full table.

\cc @billgeo