### PR TITLE
Improve dependency documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,6 +68,12 @@ before_install:
   # Install postgresql-tableversion
   - sudo env "PATH=$PATH" pgxn install
     https://github.com/linz/postgresql-tableversion/archive/1.4.0.tar.gz
+  # Install linz-bde-uploader
+  - wget https://github.com/linz/linz_bde_uploader/archive/2.4.0.tar.gz
+  - tar xzf 2.4.0.tar.gz && cd linz_bde_uploader-2.4.0
+  - ./configure && make
+  - sudo env "PATH=$PATH" make install
+  - cd .. && rm -rf 2.4.0.tar.gz linz_bde_uploader-2.4.0
 script:
   - make
   - make check || { cat regression.diffs; false; }

--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ Dependencies
 ------------
 
 Requires [linz-bde-schema](https://github.com/linz/linz-bde-schema) (v1.1.0+),
-[table_version](https://github.com/linz/postgresql-tableversion) (v1.4.0+) and
+[table_version](https://github.com/linz/postgresql-tableversion) (v1.4.0+),
+[dbpatch](https://github.com/linz/postgresql-dbpatch) (v1.2.0+) and
 [linz_bde_uploader](https://github.com/linz/linz_bde_uploader) (v2.4.0+)
 packages.
 

--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ Dependencies
 ------------
 
 Requires [linz-bde-schema](https://github.com/linz/linz-bde-schema) (v1.1.0+),
-and [table_version](https://github.com/linz/postgresql-tableversion) (v1.4.0+)
-packages
+[table_version](https://github.com/linz/postgresql-tableversion) (v1.4.0+) and
+[linz_bde_uploader](https://github.com/linz/linz_bde_uploader) (v2.4.0+)
+packages.
 
 License
 ---------------------

--- a/debian/control
+++ b/debian/control
@@ -14,7 +14,7 @@ Architecture: all
 Depends: ${misc:Depends},
          postgresql-9.3-tableversion (>= 1.4.0),
          postgresql-9.3-dbpatch (>= 1.2.0),
-         linz-bde-uploader (>= 2.4.0)
-Recommends: linz-bde-schema
+         linz-bde-uploader (>= 2.4.0),
+         linz-bde-schema
 Description: Provides the schemas and functions to generate the Landonline
  layers and tables that are available on the LDS.

--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,9 @@ Vcs-Browser: https://github.com/linz/linz-lds-bde-schema.git
 Package: linz-lds-bde-schema
 Architecture: all
 Depends: ${misc:Depends},
-         postgresql-9.3-tableversion (>= 1.4.0)
+         postgresql-9.3-tableversion (>= 1.4.0),
+         postgresql-9.3-dbpatch (>= 1.2.0),
+         linz-bde-uploader (>= 2.4.0)
 Recommends: linz-bde-schema
 Description: Provides the schemas and functions to generate the Landonline
  layers and tables that are available on the LDS.

--- a/scripts/linz-lds-bde-schema-load.in
+++ b/scripts/linz-lds-bde-schema-load.in
@@ -41,19 +41,9 @@ if test -z "$DB_NAME"; then
     exit 1
 fi
 
-# Always enable table_version (is required!)
-PGBIN=`pg_config --bindir`
-if test -n "$PGBIN"; then
-    PATH=$PATH:$PGBIN
-else
-    # Wild guess where table_version-loader and dbpatch-loader
-    # will be found (as of versions 1.4.0 and 1.2.0 they were
-    # installed in PostgreSQL bin dir)
-    for f in /usr/lib/postgresql/*/bin/; do
-      PATH="$PATH:$f";
-    done
-fi
-
+# Load linz-bde-uploader schema
+# guess where linz-bde-uploader-schema-load could be
+PATH="$PATH:$HOME/perl5/bin";
 LOADER=linz-bde-uploader-schema-load
 which $LOADER > /dev/null || {
     echo "$0 depends on $LOADER, which cannot be found in current PATH." >&2

--- a/scripts/linz-lds-bde-schema-load.in
+++ b/scripts/linz-lds-bde-schema-load.in
@@ -54,16 +54,16 @@ else
     done
 fi
 
-LOADER=table_version-loader
+LOADER=linz-bde-uploader-schema-load
 which $LOADER > /dev/null || {
     echo "$0 depends on $LOADER, which cannot be found in current PATH." >&2
-    echo "Did you install table_version ? (1.4.0 or later needed)" >&2
+    echo "Did you install linz-bde-uploader ? (2.4.0 or later needed)" >&2
     exit 1
 }
 
 OPTS=
 if test "${EXTENSION_MODE}" = "off"; then
-    OPTS="--no-extension"
+    OPTS="--noextension"
 fi
 ${LOADER} ${OPTS} $DB_NAME || exit 1
 


### PR DESCRIPTION
Documents dependency on linz-bde-uploader and (as a consequence)
dbpatch.  Have linz-lds-bde-schema-load load the linz-bde-uploader
schema with its 2.4.0+ loader, delegating to it table_version and
dbpatch loading.