### PR TITLE
Reorganize DVL handling

### DIFF
--- a/sql/04-lds_layer_functions.sql.in
+++ b/sql/04-lds_layer_functions.sql.in
@@ -568,6 +568,9 @@ CREATE OR REPLACE FUNCTION lds.LDS_CreateTitleExclusionTables(
 )
 RETURNS
 	BOOLEAN AS $$
+DECLARE
+	num_protected_titles int;
+	found_unused_ids int;
 BEGIN
 	IF (
 		SELECT
@@ -623,7 +626,9 @@ BEGIN
 
 	CREATE TEMP TABLE tmp_protected_titles AS
 	SELECT
-		TTL.title_no
+		TTL.title_no,
+		ROW_NUMBER() over (order by TTL.title_no) as ser,
+		NULL::int as prp_id
 	FROM
 		bde.crs_title TTL
 	LEFT JOIN tmp_excluded_titles EXL ON TTL.title_no = EXL.title_no
@@ -643,21 +648,46 @@ BEGIN
 	) AND
 	EXL.title_no IS NULL;
 
+	GET DIAGNOSTICS num_protected_titles = ROW_COUNT;
+
 	ALTER TABLE tmp_protected_titles ADD PRIMARY KEY (title_no);
 	ANALYSE tmp_protected_titles;
 
+	RAISE INFO 'Started creating temp table tmp_unused_proprietor_ids';
+
+	-- Need to extract `num_protected_titles` unused identifiers now
 	CREATE TEMP TABLE tmp_unused_proprietor_ids AS
-	SELECT row_number() over (order by id) ser, id
-	FROM (
-		SELECT generate_series( MIN(id), MIN(id)+1000 ) id
-		FROM bde.crs_proprietor
-        EXCEPT
-        SELECT id FROM bde.crs_proprietor
-	) foo
-    ;
+	SELECT
+		row_number() over (order by id) ser,
+		id + 1 id
+	FROM bde.crs_proprietor p1
+	WHERE NOT EXISTS (
+		SELECT NULL
+		FROM bde.crs_proprietor p2
+		WHERE p2.id = p1.id + 1
+	) LIMIT num_protected_titles;
+
+	GET DIAGNOSTICS found_unused_ids = ROW_COUNT;
+
+	RAISE INFO 'Found %/% unused ids', found_unused_ids, num_protected_titles;
 
 	ALTER TABLE tmp_unused_proprietor_ids ADD PRIMARY KEY (ser);
 	ANALYSE tmp_unused_proprietor_ids;
+
+	RAISE INFO 'Assign unused proprietor ids to protected titles';
+
+	UPDATE tmp_protected_titles t SET prp_id = u.id
+	FROM tmp_unused_proprietor_ids u
+	WHERE u.ser = t.ser;
+
+	IF found_unused_ids < num_protected_titles THEN
+		UPDATE tmp_protected_titles t
+		SET prp_id = (SELECT max(id) FROM bde.crs_proprietor) + ROW_NUMBER() over (order by ser)
+		WHERE prp_id IS NULL;
+	END IF;
+
+	-- This table is not needed anymore, drop it
+	DROP TABLE tmp_unused_proprietor_ids;
 
 	RETURN TRUE;
 END;
@@ -675,7 +705,6 @@ DECLARE
 BEGIN
 	DROP TABLE tmp_excluded_titles;
 	DROP TABLE tmp_protected_titles;
-	DROP TABLE tmp_unused_proprietor_ids;
 	DROP TABLE tmp_training_titles;
 	RETURN TRUE;
 EXCEPTION
@@ -2512,14 +2541,7 @@ BEGIN
         corporate_name
     )
     SELECT
-        COALESCE(
-            UNS.id,
-            -- If no unused ID was found, use future IDs.
-            -- These will be logged as UPDATEs once used,
-            -- but only the old value will be recognizable
-            --
-            max(PRP.id) over () + ROW_NUMBER() over ()
-        ),
+        PRO.prp_id,
         TTS.id,
         TTS.title_no,
         TTS.land_district,
@@ -2531,15 +2553,11 @@ BEGIN
     FROM
         tmp_title_estates TTS
         JOIN bde.crs_estate_share ETS ON TTS.id = ETS.ett_id AND ETS.status = 'REGD'
-        JOIN (
-            SELECT row_number() over (order by id) ser, *
-            FROM bde.crs_proprietor
-        ) PRP ON ETS.id = PRP.ets_id AND PRP.status = 'REGD'
+        JOIN bde.crs_proprietor PRP ON ETS.id = PRP.ets_id AND PRP.status = 'REGD'
         LEFT JOIN tmp_protected_titles PRO ON TTS.title_no = PRO.title_no
         LEFT JOIN bde.crs_sys_code PRPT ON PRPT.scg_code = 'PRPT' AND PRPT.code = PRP.type
         LEFT JOIN bde.crs_sys_code NMSF ON NMSF.scg_code = 'NMSF' AND NMSF.code = PRP.name_suffix
         LEFT JOIN bde.crs_sys_code TSDS ON PRP.status = TSDS.code AND TSDS.scg_code = 'TSDS'
-        LEFT JOIN tmp_unused_proprietor_ids UNS ON PRP.ser = UNS.ser
     WHERE
         PRO.title_no IS NOT NULL;
 

--- a/sql/04-lds_layer_functions.sql.in
+++ b/sql/04-lds_layer_functions.sql.in
@@ -646,13 +646,18 @@ BEGIN
 	ALTER TABLE tmp_protected_titles ADD PRIMARY KEY (title_no);
 	ANALYSE tmp_protected_titles;
 
-	CREATE TEMP TABLE tmp_unregistered_proprietors AS
+	CREATE TEMP TABLE tmp_unused_proprietor_ids AS
 	SELECT row_number() over (order by id) ser, id
-	FROM bde.crs_proprietor
-	WHERE status <> 'REGD';
+	FROM (
+		SELECT generate_series( MIN(id), MIN(id)+1000 ) id
+		FROM bde.crs_proprietor
+        EXCEPT
+        SELECT id FROM bde.crs_proprietor
+	) foo
+    ;
 
-	ALTER TABLE tmp_unregistered_proprietors ADD PRIMARY KEY (ser);
-	ANALYSE tmp_unregistered_proprietors;
+	ALTER TABLE tmp_unused_proprietor_ids ADD PRIMARY KEY (ser);
+	ANALYSE tmp_unused_proprietor_ids;
 
 	RETURN TRUE;
 END;
@@ -670,7 +675,7 @@ DECLARE
 BEGIN
 	DROP TABLE tmp_excluded_titles;
 	DROP TABLE tmp_protected_titles;
-	DROP TABLE tmp_unregistered_proprietors;
+	DROP TABLE tmp_unused_proprietor_ids;
 	DROP TABLE tmp_training_titles;
 	RETURN TRUE;
 EXCEPTION
@@ -2534,7 +2539,7 @@ BEGIN
         LEFT JOIN bde.crs_sys_code PRPT ON PRPT.scg_code = 'PRPT' AND PRPT.code = PRP.type
         LEFT JOIN bde.crs_sys_code NMSF ON NMSF.scg_code = 'NMSF' AND NMSF.code = PRP.name_suffix
         LEFT JOIN bde.crs_sys_code TSDS ON PRP.status = TSDS.code AND TSDS.scg_code = 'TSDS'
-        LEFT JOIN tmp_unregistered_proprietors UNS ON PRP.ser = UNS.ser
+        LEFT JOIN tmp_unused_proprietor_ids UNS ON PRP.ser = UNS.ser
     WHERE
         PRO.title_no IS NOT NULL;
 

--- a/sql/04-lds_layer_functions.sql.in
+++ b/sql/04-lds_layer_functions.sql.in
@@ -2486,6 +2486,39 @@ BEGIN
         PRO.title_no IS NULL;
 
 
+
+    -- Following subquery picks unused identifiers among
+    -- the lowest 1000. If there aren't enough entries
+    -- among those tables there will be a problem, so
+    -- we'd better first check how many we need, using
+    -- a temporary table. There might still be not enough
+    -- entries but in that case we'll use higher
+    -- identifiers.
+    --
+    -- TODO: create a temporary table instead, trying
+    --       best effort to find at least the required
+    --       number of identifiers
+    --
+    WITH unused_ids AS (
+        SELECT
+            row_number() over (ORDER BY id) ser,
+            id
+        FROM (
+            SELECT
+                id
+            FROM (
+                SELECT
+                    generate_series( MIN(id), MIN(id)+1000 ) id
+                FROM
+                    lds.title_owners_aspatial
+            ) gs
+            EXCEPT
+            SELECT
+                id
+            FROM
+                lds.title_owners_aspatial
+         ) bar
+    )
     INSERT INTO tmp_title_owners_aspatial(
         id,
         tte_id,
@@ -2498,7 +2531,14 @@ BEGIN
         corporate_name
     )
     SELECT
-        (select min(id) from tmp_title_owners_aspatial) - row_number() over (),
+        COALESCE(
+            UNS.id,
+            -- If no unused ID was found, use future IDs.
+            -- These will be logged as UPDATEs once used,
+            -- but only the old value will be recognizable
+            --
+            max(PRP.id) over () + ROW_NUMBER() over ()
+        ),
         TTS.id,
         TTS.title_no,
         TTS.land_district,
@@ -2510,11 +2550,15 @@ BEGIN
     FROM
         tmp_title_estates TTS
         JOIN bde.crs_estate_share ETS ON TTS.id = ETS.ett_id AND ETS.status = 'REGD'
-        JOIN bde.crs_proprietor PRP ON ETS.id = PRP.ets_id AND PRP.status = 'REGD'
+        JOIN (
+            SELECT row_number() over (order by id) ser, *
+            FROM bde.crs_proprietor
+        ) PRP ON ETS.id = PRP.ets_id AND PRP.status = 'REGD'
         LEFT JOIN tmp_protected_titles PRO ON TTS.title_no = PRO.title_no
         LEFT JOIN bde.crs_sys_code PRPT ON PRPT.scg_code = 'PRPT' AND PRPT.code = PRP.type
         LEFT JOIN bde.crs_sys_code NMSF ON NMSF.scg_code = 'NMSF' AND NMSF.code = PRP.name_suffix
         LEFT JOIN bde.crs_sys_code TSDS ON PRP.status = TSDS.code AND TSDS.scg_code = 'TSDS'
+        LEFT JOIN unused_ids UNS ON PRP.ser = UNS.ser
     WHERE
         PRO.title_no IS NOT NULL;
 

--- a/sql/04-lds_layer_functions.sql.in
+++ b/sql/04-lds_layer_functions.sql.in
@@ -646,6 +646,14 @@ BEGIN
 	ALTER TABLE tmp_protected_titles ADD PRIMARY KEY (title_no);
 	ANALYSE tmp_protected_titles;
 
+	CREATE TEMP TABLE tmp_unregistered_proprietors AS
+	SELECT row_number() over (order by id) ser, id
+	FROM bde.crs_proprietor
+	WHERE status <> 'REGD';
+
+	ALTER TABLE tmp_unregistered_proprietors ADD PRIMARY KEY (ser);
+	ANALYSE tmp_unregistered_proprietors;
+
 	RETURN TRUE;
 END;
 $$ LANGUAGE plpgsql VOLATILE;
@@ -662,6 +670,7 @@ DECLARE
 BEGIN
 	DROP TABLE tmp_excluded_titles;
 	DROP TABLE tmp_protected_titles;
+	DROP TABLE tmp_unregistered_proprietors;
 	DROP TABLE tmp_training_titles;
 	RETURN TRUE;
 EXCEPTION
@@ -2486,39 +2495,6 @@ BEGIN
         PRO.title_no IS NULL;
 
 
-
-    -- Following subquery picks unused identifiers among
-    -- the lowest 1000. If there aren't enough entries
-    -- among those tables there will be a problem, so
-    -- we'd better first check how many we need, using
-    -- a temporary table. There might still be not enough
-    -- entries but in that case we'll use higher
-    -- identifiers.
-    --
-    -- TODO: create a temporary table instead, trying
-    --       best effort to find at least the required
-    --       number of identifiers
-    --
-    WITH unused_ids AS (
-        SELECT
-            row_number() over (ORDER BY id) ser,
-            id
-        FROM (
-            SELECT
-                id
-            FROM (
-                SELECT
-                    generate_series( MIN(id), MIN(id)+1000 ) id
-                FROM
-                    lds.title_owners_aspatial
-            ) gs
-            EXCEPT
-            SELECT
-                id
-            FROM
-                lds.title_owners_aspatial
-         ) bar
-    )
     INSERT INTO tmp_title_owners_aspatial(
         id,
         tte_id,
@@ -2558,7 +2534,7 @@ BEGIN
         LEFT JOIN bde.crs_sys_code PRPT ON PRPT.scg_code = 'PRPT' AND PRPT.code = PRP.type
         LEFT JOIN bde.crs_sys_code NMSF ON NMSF.scg_code = 'NMSF' AND NMSF.code = PRP.name_suffix
         LEFT JOIN bde.crs_sys_code TSDS ON PRP.status = TSDS.code AND TSDS.scg_code = 'TSDS'
-        LEFT JOIN unused_ids UNS ON PRP.ser = UNS.ser
+        LEFT JOIN tmp_unregistered_proprietors UNS ON PRP.ser = UNS.ser
     WHERE
         PRO.title_no IS NOT NULL;
 

--- a/sql/04-lds_layer_functions.sql.in
+++ b/sql/04-lds_layer_functions.sql.in
@@ -2498,7 +2498,7 @@ BEGIN
         corporate_name
     )
     SELECT
-        PRP.id,
+        (select min(id) from tmp_title_owners_aspatial) - row_number() over (),
         TTS.id,
         TTS.title_no,
         TTS.land_district,

--- a/sql/04-lds_layer_functions.sql.in
+++ b/sql/04-lds_layer_functions.sql.in
@@ -2510,7 +2510,6 @@ BEGIN
         TTS.title_no,
         TTS.land_district::VARCHAR(100),
         TSDS.char_value AS status,
-        PRP.status AS status_code,
         ETS.share::VARCHAR(100) AS estate_share,
         PRPT.char_value::VARCHAR(10) AS owner_type,
         PRP.prime_surname,
@@ -2535,7 +2534,6 @@ BEGIN
         title_no,
         land_district,
         status,
-        status_code,
         estate_share,
         owner_type,
         corporate_name
@@ -2545,21 +2543,14 @@ BEGIN
         TTS.id,
         TTS.title_no,
         TTS.land_district,
-        TSDS.char_value AS status,
-        PRP.status AS status_code,
+        'Registered',
         ETS.share,
         'Corporate',
         LDS_GetProtectedText(PRO.title_no)
     FROM
         tmp_title_estates TTS
         JOIN bde.crs_estate_share ETS ON TTS.id = ETS.ett_id AND ETS.status = 'REGD'
-        JOIN bde.crs_proprietor PRP ON ETS.id = PRP.ets_id AND PRP.status = 'REGD'
-        LEFT JOIN tmp_protected_titles PRO ON TTS.title_no = PRO.title_no
-        LEFT JOIN bde.crs_sys_code PRPT ON PRPT.scg_code = 'PRPT' AND PRPT.code = PRP.type
-        LEFT JOIN bde.crs_sys_code NMSF ON NMSF.scg_code = 'NMSF' AND NMSF.code = PRP.name_suffix
-        LEFT JOIN bde.crs_sys_code TSDS ON PRP.status = TSDS.code AND TSDS.scg_code = 'TSDS'
-    WHERE
-        PRO.title_no IS NOT NULL;
+        JOIN tmp_protected_titles PRO ON TTS.title_no = PRO.title_no;
 
     RAISE INFO 'Finished creating temp table tmp_title_owners_aspatial';
 

--- a/sql/06-bde_ext_functions.sql.in
+++ b/sql/06-bde_ext_functions.sql.in
@@ -395,13 +395,14 @@ BEGIN
 
     DROP TABLE IF EXISTS dvl_prp;
     CREATE TEMPORARY TABLE dvl_prp
-    (title_no VARCHAR, prp_id INTEGER)
+    (title_no VARCHAR, prp_id INTEGER, dvl_prp_id INTEGER)
     ON COMMIT DROP;
 
     INSERT INTO dvl_prp
     SELECT
         DVL.title_no AS title_no,
-        PRP.id AS prp_id
+        PRP.id AS prp_id,
+        DVL.prp_id AS dvl_prp_id
     FROM
         tmp_protected_titles DVL
     JOIN crs_title_estate ETT ON DVL.title_no = ETT.ttl_title_no
@@ -439,15 +440,17 @@ BEGIN
             ALS.id,
             ALS.prp_id,
             -- Mask protected titles
-            CASE WHEN D2P.title_no IS NOT NULL THEN lds.LDS_GetProtectedText(D2P.title_no) ELSE ALS.surname END AS surname,
-            CASE WHEN D2P.title_no IS NOT NULL THEN NULL ELSE ALS.other_names END AS other_names
+            ALS.surname,
+            ALS.other_names
         FROM crs_alias ALS
         JOIN crs_proprietor PRP ON ALS.prp_id = PRP.id
         LEFT JOIN DVL_PRP D2P ON PRP.id = D2P.prp_id
         WHERE PRP.status <> 'LDGE'
+        AND D2P.title_no IS NULL
         -- Completely exclude training titles and pending titles
         AND PRP.id NOT IN (SELECT prp_id FROM exclude_prp)
         ORDER BY id;
+
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();


### PR DESCRIPTION
Uses identifiers lower than the minimum identifier used for
non-protected records. They will not necessarely be persistent
but should reduce chances of identifying toggles.

Open for discussion

\cc @palmerj @iharrison @vlindsay