### PR TITLE
Fix typo in LDS_GetLandDistict function name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ this file.
 ### Enhanced
 - Reduce list of tables affecting simplified parcel layers (#165)
 - Use a DO block to bless functions, avoiding empty-lines in psql output
+- Deprecate `LDS_GetLandDistict` in favour of `LDS_GetLandDistrict` (#157)
 
 ## 1.5.0 - 2019-04-01
 ### Changed

--- a/sql/04-lds_layer_functions.sql.in
+++ b/sql/04-lds_layer_functions.sql.in
@@ -4168,7 +4168,7 @@ BEGIN
             SCO.char_value AS surveyed_type,
             COS.name AS coordinate_system,
             CASE WHEN SUR.wrk_id IS NULL THEN
-                LDS_GetLandDistict(MRKL.shape)
+                LDS_GetLandDistrict(MRKL.shape)
             ELSE
                 SUR.land_district
             END as land_district,
@@ -4246,7 +4246,7 @@ BEGIN
         SCO.char_value,
         COS.name,
         CASE WHEN SUR.wrk_id IS NULL THEN
-            LDS_GetLandDistict(MRKL.shape)
+            LDS_GetLandDistrict(MRKL.shape)
         ELSE
             SUR.land_district
         END as land_district,

--- a/sql/04-lds_layer_functions.sql.in
+++ b/sql/04-lds_layer_functions.sql.in
@@ -432,8 +432,7 @@ BEGIN
 END;
 $$;
 
--- Should this be District ? (missing `r')
-CREATE OR REPLACE FUNCTION lds.LDS_GetLandDistict(p_shape GEOMETRY)
+CREATE OR REPLACE FUNCTION lds.LDS_GetLandDistrict(p_shape GEOMETRY)
 RETURNS
     TEXT
 AS $$
@@ -448,6 +447,18 @@ AS $$
     ORDER BY
         ST_Distance(LDT.shape, $1) ASC
 $$ LANGUAGE sql STABLE;
+
+DO $$ BEGIN PERFORM pg_temp.bless_lds_bde_function('lds.LDS_GetLandDistrict(GEOMETRY)'); END; $$;
+
+-- This should be District (missing `r') but is retained for backward
+-- compatibility. The lds.LDS_GetLandDistrict function was introduced
+-- in version 1.6.0, this old one can probably be dropped somewhen
+-- in version 1.8.0 or so...
+CREATE OR REPLACE FUNCTION lds.LDS_GetLandDistict(p_shape GEOMETRY)
+RETURNS TEXT AS $$ BEGIN
+    RAISE WARNING 'Please use LDS_GetLandDistrict instead of LDS_GetLandDistict';
+    SELECT lds.LDS_GetLandDistrict($1);
+END; $$ LANGUAGE 'plpgsql';
 
 DO $$ BEGIN PERFORM pg_temp.bless_lds_bde_function('lds.LDS_GetLandDistict(GEOMETRY)'); END; $$;
 


### PR DESCRIPTION
Retains the bogus signature, for backward compatibility, while raising
a warning for users, recommending to use the new signature.

Closes #157

Includes CHANGELOG