### PR TITLE
Do not TRUNCATE an empty table (what's the point?)

### DIFF
--- a/sql/04-lds_layer_functions.sql.in
+++ b/sql/04-lds_layer_functions.sql.in
@@ -178,8 +178,6 @@ BEGIN
 
         PERFORM LDS.LDS_DropTableContrainstsAndIndexes(p_table);
 
-        EXECUTE 'TRUNCATE ' || p_table;
-
         v_count := bde_control.bde_ExecuteTemplate(
             p_data_insert_tmpl,
             ARRAY[p_table::TEXT]


### PR DESCRIPTION
As of table_version 1.8.0+ TRUNCATE will be forbidden on versioned
tables, so better not do it when not needed...