### PR TITLE
ci: test uninstall

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,6 +82,9 @@ jobs:
         # Post-install tests
         make installcheck
         make installcheck-stdout
+    - name: Test uninstall
+      run: |
+        make uninstall
     - name: Test docs building
       run: |
         xvfb-run make docs


### PR DESCRIPTION
If it works, it ensures the later tests for debian package use
are not polluted by leftover from the "manual" install