### PR TITLE
ci: add package building and publishing steps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,13 @@
 name: test
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - packagecloud
+  pull_request:
+    branches:
+      - '*'
 
 jobs:
 
@@ -96,3 +103,35 @@ jobs:
       run: |
         make check-publisher
       if: matrix.pg >= 10
+
+  package:
+    if: ${{ success() }}
+    name: Package for Debian
+    runs-on: ubuntu-18.04
+    strategy:
+        matrix:
+            distro: [ 'bionic' ]
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Determine packagecloud publication target
+      run: |
+        # TODO: it would be nice to turn this into a single-liner in
+        #       github-action syntax
+        echo "GitHub ref: ${{ github.ref }}"
+        echo "GitHub event_name: ${{ github.event_name }}"
+        REPO=
+        if test "${{ github.event_name }}" = 'push'; then
+          if expr "${{ github.ref }}" : "refs/tags/" > /dev/null; then
+            REPO=test
+          else
+            REPO=dev
+          fi
+        fi
+        echo "REPO: $REPO"
+        echo ::set-env name=REPO::"$REPO"
+
+    - uses: linz/linz-software-repository@master
+      with:
+        packagecloud_token: ${{ secrets.LINZCI_PACKAGECLOUD_TOKEN }}
+        publish_to_repository: ${{ env.REPO }}


### PR DESCRIPTION
Builds packages using linz-software-repository action
Publish packages:
    - to "dev" repository on push to master or packagecloud branches
    - to "test" repository on tag