### PR TITLE
Drop ORDER BY in simplified tables creation code

### DIFF
--- a/sql/04-lds_layer_functions.sql.in
+++ b/sql/04-lds_layer_functions.sql.in
@@ -442,7 +442,7 @@ AS $$
     WHERE
         LDT.loc_id = LOC.id AND
         LDT.shape && $1
-    ORDER BY
+    ORDER BY -- Do we really need this ORDER BY here ? --strk 2020-07-09
         ST_Distance(LDT.shape, $1) ASC
 $$ LANGUAGE sql STABLE;
 
@@ -878,8 +878,6 @@ BEGIN
             tmp_geodetic_marks
         WHERE
             cos_id_official = 109
-        ORDER BY
-            id;
     $sql$;
 
     PERFORM LDS.LDS_UpdateSimplifiedTable(
@@ -926,8 +924,6 @@ BEGIN
             tmp_geodetic_marks
         WHERE
             cos_id_official = 142
-        ORDER BY
-            id;
     $sql$;
 
     PERFORM LDS.LDS_UpdateSimplifiedTable(
@@ -1038,7 +1034,7 @@ BEGIN
             LEFT JOIN %2% AS ORG ON (ORG.nod_id = TMP.nod_id AND ORG.coordinate_system = TMP.coordinate_system)
         WHERE
             TMP.cos_id_official = 109
-        ORDER BY
+        ORDER BY -- used for consistent id=nextval()
             TMP.nod_id,
             TMP.coordinate_system
     $sql$;
@@ -1075,9 +1071,6 @@ BEGIN
             tmp_geodetic_vertical_mark
         WHERE
             cos_id_official = 109
-        ORDER BY
-            nod_id,
-            coordinate_system
     $sql$;
 
     PERFORM LDS.LDS_UpdateSimplifiedTable(
@@ -1125,7 +1118,7 @@ BEGIN
             LEFT JOIN %2% AS ORG ON (ORG.nod_id = TMP.nod_id AND ORG.coordinate_system = TMP.coordinate_system)
         WHERE
             TMP.cos_id_official = 142
-        ORDER BY
+        ORDER BY -- used for consistent id=nextval()
             TMP.nod_id,
             TMP.coordinate_system
     $sql$;
@@ -1160,9 +1153,6 @@ BEGIN
             tmp_geodetic_vertical_mark
         WHERE
             cos_id_official = 142
-        ORDER BY
-            nod_id,
-            coordinate_system
     $sql$;
 
     PERFORM LDS.LDS_UpdateSimplifiedTable(
@@ -1333,7 +1323,7 @@ BEGIN
             LEFT JOIN %2% AS ORG ON (ORG.nod_id = TMP.nod_id AND ORG.control_network = TMP.control_network)
         WHERE
             TMP.cos_id_official = 109
-        ORDER BY
+        ORDER BY -- used for consistent id=nextval()
             TMP.nod_id,
             TMP.control_network
     $sql$;
@@ -1374,9 +1364,6 @@ BEGIN
             tmp_geodetic_network_marks
         WHERE
             cos_id_official = 109
-        ORDER BY
-            nod_id,
-            control_network
     $sql$;
 
     PERFORM LDS.LDS_UpdateSimplifiedTable(
@@ -1522,8 +1509,6 @@ BEGIN
             t
         WHERE
             row_number = 1
-        ORDER BY
-            id;
     $sql$;
 
     PERFORM LDS.LDS_UpdateSimplifiedTable(
@@ -1688,7 +1673,7 @@ BEGIN
         bde.crs_stat_act_parcl SAP
         LEFT JOIN  bde.crs_sys_code SAPA ON SAPA.scg_code ='SAPA' AND SAP.action = SAPA.code
         LEFT JOIN  bde.crs_sys_code SAPS ON SAPS.scg_code ='SAPS' AND SAP.status = SAPS.code
-    ORDER BY SAP.par_id;
+    ;
 
     ANALYSE tmp_par_stat_action;
 
@@ -1900,8 +1885,7 @@ BEGIN
         (ST_Contains(WDR.shape, PAR.shape) OR PAR.shape IS NULL)
     GROUP BY
         1, 2, 4, 5, 6, 7, 8, 10, 11, 12
-    ORDER BY
-        PAR.id;
+    ;
 
     RAISE NOTICE 'Finished creating temp table tmp_parcels';
 
@@ -3106,16 +3090,6 @@ BEGIN
                 encumbrancees
             FROM
                 tmp_title_memorials
-            ORDER BY
-                title_no,
-                instrument_number,
-                memorial_text,
-                instrument_type,
-                land_district,
-                instrument_lodged_datetime,
-                encumbrancees,
-                "current" DESC,
-                id
         )
         SELECT
             id,
@@ -3129,7 +3103,6 @@ BEGIN
             encumbrancees
         FROM
             tmp_title_memorials_nodups
-        ORDER BY id;
     $sql$;
 
     PERFORM LDS.LDS_UpdateSimplifiedTable(
@@ -3286,22 +3259,6 @@ BEGIN
         FROM
             temp_title_memorial_text TXT
             JOIN title_memorials TTM ON TXT.ttm_id = TTM.id
-        ORDER BY
-            TTM.title_no,
-            TXT.new_title_legal_description,
-            TXT.new_title_reference,
-            TXT.easement_type,
-            TXT.servient_tenement,
-            TXT.easement_area,
-            TXT.dominant_tenement_or_grantee,
-            TXT.statutory_restriction,
-            TXT.principal_unit,
-            TXT.future_development_unit,
-            TXT.assessory_unit,
-            TXT.title_issued,
-            TXT.curr_hist_flag DESC,
-            TXT.ttm_id,
-            TXT.id;
     $sql$;
 
     PERFORM LDS.LDS_UpdateSimplifiedTable(
@@ -3514,8 +3471,6 @@ BEGIN
             WRK.restricted = 'N'
         GROUP BY
             1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11
-        ORDER BY
-            WRK.id;
     $sql$;
 
     PERFORM LDS.LDS_UpdateSimplifiedTable(
@@ -3575,8 +3530,6 @@ BEGIN
             END AS shape
         FROM
             adjustments
-        ORDER BY
-            id;
     $sql$;
 
     PERFORM LDS.LDS_UpdateSimplifiedTable(
@@ -3625,8 +3578,6 @@ BEGIN
             ADJ.id,
             ADJ.adjust_datetime,
             SUR.survey_reference
-        ORDER BY
-            ADJ.id;
     $sql$;
 
     PERFORM LDS.LDS_UpdateSimplifiedTable(
@@ -3675,8 +3626,6 @@ BEGIN
             ADJ.id,
             ADJ.adjust_datetime,
             SUR.survey_reference
-        ORDER BY
-            ADJ.id;
     $sql$;
 
     PERFORM LDS.LDS_UpdateSimplifiedTable(
@@ -3937,8 +3886,6 @@ BEGIN
             t
         WHERE
             row_number = 1
-        ORDER BY
-            id;
     $sql$;
 
     PERFORM LDS.LDS_UpdateSimplifiedTable(
@@ -4191,8 +4138,6 @@ BEGIN
             OBN.status = 'AUTH' AND
             OBN.surveyed_class IN ('ADPT', 'CALC', 'MEAS') AND
             OBN.value_1 >= 0
-        ORDER BY
-            OBN.id;
     $sql$;
 
     PERFORM LDS.LDS_UpdateSimplifiedTable(

--- a/sql/06-bde_ext_functions.sql.in
+++ b/sql/06-bde_ext_functions.sql.in
@@ -249,7 +249,6 @@ BEGIN
     FROM crs_street_address SAD
     WHERE SAD.house_number != 'UNH'
     AND SAD.range_low != 0
-    ORDER BY id;
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -297,7 +296,7 @@ BEGIN
     SELECT TTM.id FROM crs_title_memorial TTM
     WHERE TTM.status <> 'LDGE'
     AND TTM.ttl_title_no NOT IN (SELECT title_no FROM tmp_excluded_titles)
-    ORDER BY id;
+    ;
 
     CREATE INDEX TTM_LDG_idx ON TTM_LDG (id);
     ANALYSE TTM_LDG;
@@ -386,7 +385,6 @@ BEGIN
             LEFT JOIN crs_title_memorial TTM ON TMT.ttm_id = TTM.id
             LEFT JOIN crs_ttl_inst TIN ON TTM.act_tin_id_crt = TIN.id
             LEFT JOIN crs_transact_type TRT ON (TRT.grp = TIN.trt_grp AND TRT.type = TIN.trt_type)
-        ORDER BY audit_id;
         $sql$;
 
     RAISE NOTICE '***  TABLE UPDATE END TMT_SUB4(TMT)% - % ***',v_table,clock_timestamp();
@@ -459,7 +457,6 @@ BEGIN
         WHERE PRP.status <> 'LDGE'
         -- Completely exclude training titles and pending titles
         AND PRP.id NOT IN (SELECT prp_id FROM exclude_prp)
-        ORDER BY id;
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -503,7 +500,6 @@ BEGIN
             ADJ.audit_id
         FROM
             crs_adjustment_run ADJ
-        ORDER BY id;
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -548,7 +544,6 @@ BEGIN
         LEFT JOIN dvl_prp d2p ON prp.id = d2p.prp_id
         WHERE prp.status <> 'LDGE'
         AND prp.id NOT IN ( SELECT exclude_prp.prp_id FROM exclude_prp)
-        ORDER BY id;
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -584,7 +579,6 @@ BEGIN
     WHERE TRN.title_no IS NULL
       AND ENE.status <> 'LDGE'
       AND T.status <> 'PEND'
-    ORDER BY id;
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -630,7 +624,6 @@ BEGIN
     FROM crs_encumbrance
     WHERE id NOT IN (SELECT enc_id FROM TRN)
     AND status <> 'LDGE'
-    ORDER BY id;
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -671,7 +664,6 @@ BEGIN
         ON NMI.ttl_title_no = DVL.title_no
         WHERE NMI.status <> 'LDGE'
         AND NMI.ttl_title_no NOT IN (SELECT title_no FROM tmp_excluded_titles)
-        ORDER BY id;
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -721,7 +713,6 @@ BEGIN
         FROM crs_enc_share ENS
         WHERE ENS.status <> 'LDGE'
         AND ENS.id NOT IN (SELECT id FROM TRN_ENS)
-        ORDER BY id;
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -774,7 +765,6 @@ BEGIN
         FROM crs_estate_share ETS
         WHERE ETS.status <> 'LDGE'
         AND ETS.id NOT IN (SELECT id FROM EXL_ETS)
-        ORDER BY id;
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -816,7 +806,6 @@ BEGIN
             LGD.ttl_title_no IS NULL
             OR LGD.ttl_title_no NOT IN (SELECT title_no FROM tmp_excluded_titles)
         )
-        ORDER BY id;
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -858,7 +847,6 @@ BEGIN
             JOIN crs_parcel_ring PRI ON PRI.id = PAB.pri_id
             JOIN crs_parcel PAR ON PAR.id = PRI.par_id
             WHERE PAR.status != 'PEND'
-            ORDER BY lin_id
         ),
         LIN_ORD (
             id,
@@ -892,7 +880,7 @@ BEGIN
                 description,
                 shape
             FROM crs_line
-            ORDER BY id)
+            )
         SELECT
             LIN_ORD.id,
             LIN_ORD.boundary,
@@ -910,8 +898,6 @@ BEGIN
             LIN_ORD.shape
         FROM LIN_ORD
         WHERE LIN_ORD.id IN (SELECT lin_id FROM PAB_LIN)
-        ORDER BY id;
-
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -954,7 +940,6 @@ BEGIN
             MNT."desc"
         FROM crs_maintenance MNT
         WHERE MNT.mrk_id in (SELECT id FROM MNT_MRK)
-        ORDER BY audit_id;
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -1014,7 +999,6 @@ BEGIN
             MRK."desc"
         FROM crs_mark MRK
         WHERE MRK.status <> 'PEND'
-        ORDER BY id;
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -1047,7 +1031,6 @@ BEGIN
         FROM crs_mark_name MKN
         JOIN crs_mark MRK ON MKN.mrk_id = MRK.id
         WHERE MRK.status <> 'PEND'
-        ORDER BY audit_id;;
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -1115,7 +1098,6 @@ BEGIN
         JOIN crs_mark MRK ON MRK.id = MPS.mrk_id
         WHERE MPS.status <> 'PROV'
         AND MRK.status <> 'PEND'
-        ORDER BY audit_id;
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -1161,7 +1143,6 @@ BEGIN
             NOD.shape
         FROM crs_node NOD
         WHERE NOD.status <> 'PEND'
-        ORDER BY id;
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -1193,7 +1174,6 @@ BEGIN
         FROM crs_node_prp_order NPO
         JOIN crs_mark MRK ON NPO.nod_id = MRK.nod_id
         WHERE MRK.status <> 'PEND'
-        ORDER BY audit_id;
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -1253,7 +1233,6 @@ BEGIN
         FROM crs_parcel PAR
         WHERE PAR.status != 'PEND'
         AND (PAR.shape IS NULL OR ST_GeometryType(PAR.shape) IN ('ST_MultiPolygon','ST_Polygon'))
-        ORDER BY id;
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -1293,7 +1272,6 @@ BEGIN
                 AND PAR.status != 'PEND'
             )
         )
-        ORDER BY id;
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -1329,7 +1307,6 @@ BEGIN
                 AND PAR.status != 'PEND'
                 )
             )
-        ORDER BY audit_id;
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -1385,7 +1362,6 @@ BEGIN
         FROM crs_parcel PAR
         WHERE PAR.status != 'PEND'
         AND ST_GeometryType(PAR.shape) = 'ST_LineString'
-        ORDER BY id;
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -1423,7 +1399,6 @@ BEGIN
             FROM crs_parcel PAR
             WHERE PAR.status != 'PEND'
             )
-        ORDER BY id;
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -1459,7 +1434,6 @@ BEGIN
             SVR.audit_id
         FROM crs_stat_version SVR
         WHERE SVR.area_class= 'TA'
-        ORDER BY audit_id;
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -1502,7 +1476,6 @@ BEGIN
             STA.audit_id
         FROM crs_statist_area STA
         WHERE STA.sav_area_class = 'TA'
-        ORDER BY id;
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -1574,7 +1547,6 @@ BEGIN
                 FROM crs_work WRK
                 WHERE WRK.restricted = 'N'
         )
-        ORDER BY wrk_id;
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -1624,7 +1596,6 @@ BEGIN
         FROM crs_title TTL
         WHERE TTL.title_no NOT IN (SELECT title_no FROM tmp_excluded_titles)
         AND TTL.status <> 'PEND'
-        ORDER BY audit_id;
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -1655,7 +1626,6 @@ BEGIN
         FROM crs_title_action TTA
         LEFT OUTER JOIN crs_title TTL ON TTA.ttl_title_no = TTL.title_no
         WHERE TTA.ttl_title_no NOT IN (SELECT title_no FROM tmp_excluded_titles)
-        ORDER BY audit_id;
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -1701,7 +1671,6 @@ BEGIN
                 )
             )
         )
-        ORDER BY id;;
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -1752,7 +1721,6 @@ BEGIN
             ON ETT.ttl_title_no = TTL.title_no
         WHERE ETT.status <> 'LDGE'
             AND ETT.ttl_title_no NOT IN (SELECT title_no FROM tmp_excluded_titles)
-        ORDER BY id;
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -1826,7 +1794,6 @@ BEGIN
         FROM crs_title_memorial TTM
         WHERE TTM.status <> 'LDGE'
         AND TTM.ttl_title_no NOT IN (SELECT title_no FROM tmp_excluded_titles)
-        ORDER BY id;
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -1856,7 +1823,6 @@ BEGIN
             TPA.source
         FROM cbe_title_parcel_association TPA
         WHERE TPA.status = 'VALD'
-        ORDER BY id;
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -1886,7 +1852,6 @@ BEGIN
             TRT.audit_id
         FROM crs_transact_type TRT
         WHERE TRT.grp IN ('TINT', 'WRKT')
-        ORDER BY audit_id;
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -1922,8 +1887,6 @@ BEGIN
         LEFT OUTER JOIN crs_title T ON TLE.ttl_title_no = T.title_no
         WHERE TLE.status <> 'LDGE'
         AND TLE.ttl_title_no NOT IN (SELECT title_no FROM tmp_excluded_titles)
-        ORDER BY id;
-
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -1965,7 +1928,6 @@ BEGIN
         WHERE TLH.status = 'REGD'
         AND (FLW.title_no NOT IN (SELECT title_no FROM tmp_excluded_titles) OR FLW.title_no IS NULL)
         AND (PRI.title_no NOT IN (SELECT title_no FROM tmp_excluded_titles) OR PRI.title_no IS NULL)
-        ORDER BY id;
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -2015,7 +1977,6 @@ BEGIN
                 SELECT tin_id FROM crs_ttl_inst_title
             ) TIN_IDS
             ON TIN_IDS.tin_id = TIN.id
-        ORDER BY id;
         $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -2062,7 +2023,6 @@ BEGIN
         FROM crs_ttl_inst TIN
         INNER JOIN bde_ext.ttl_inst TIN_IDS
             ON TIN_IDS.id = TIN.id
-        ORDER BY id;
         $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -2090,7 +2050,6 @@ BEGIN
             TIT.audit_id
         FROM crs_ttl_inst_title TIT
         WHERE TIT.ttl_title_no NOT IN (SELECT title_no FROM tmp_excluded_titles)
-        ORDER BY audit_id;
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -2140,7 +2099,6 @@ BEGIN
             USR.audit_id
         FROM crs_user USR
         WHERE USR.id IN (SELECT id FROM WRK_3ID)
-        ORDER BY audit_id;
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -2181,7 +2139,6 @@ BEGIN
             VEC.shape
         FROM crs_vector VEC
         WHERE ST_GeometryType(VEC.shape) = 'ST_LineString' OR VEC.shape IS NULL
-        ORDER BY id;
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -2222,7 +2179,6 @@ BEGIN
             VEC.shape
         FROM crs_vector VEC
         WHERE ST_GeometryType(VEC.shape) = 'ST_Point'
-        ORDER BY id;
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -2294,7 +2250,6 @@ BEGIN
             WRK.usr_id_prin_firm
         FROM crs_work WRK
         WHERE WRK.restricted = 'N'
-        ORDER BY id;
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -2332,7 +2287,6 @@ BEGIN
         FEN.shape
     FROM crs_feature_name FEN
     WHERE (FEN.shape IS NULL OR ST_GeometryType(FEN.shape) = 'ST_Point')
-    ORDER BY id;
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -2371,7 +2325,6 @@ BEGIN
         FEN.shape
      FROM crs_feature_name FEN
      WHERE ST_GeometryType(FEN.shape) = 'ST_Polygon'
-     ORDER BY id;
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -2428,7 +2381,6 @@ BEGIN
     WHERE
         COO.cos_id = 109
         AND COO.status = 'AUTH'
-    ORDER BY id;
  $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -2463,8 +2415,6 @@ BEGIN
         OFF.audit_id
     FROM
         crs_office OFF
-    ORDER BY
-        audit_id;
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();
@@ -2532,8 +2482,6 @@ BEGIN
         survey_plan_image_history
     WHERE
         row_number = 1
-    ORDER BY
-        id;
     $sql$;
 
     RAISE NOTICE '*** PERFORM TABLE UPDATE % - % ***',v_table,clock_timestamp();


### PR DESCRIPTION
ORDER should be decided by caller, there's no need to do it
at data creation time. According to chat with Jeremy Palmer
this ORDER BY was added to speed up computation of diffs
for incremental updates, but changes in that diff code around
2017 made the ORDER BY obsoleted.

This change has to be tested for performance implications.