### PR TITLE
Encode dependency on linz-bde-schema >= 1.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Dependencies
 ------------
 
 Usage requires:
- - [`linz-bde-schema`](https://github.com/linz/linz-bde-schema) (v1.1.0+)
+ - [`linz-bde-schema`](https://github.com/linz/linz-bde-schema) (v1.11.0+)
  - [`table_version`](https://github.com/linz/postgresql-tableversion) (v1.4.0+)
  - [`dbpatch`](https://github.com/linz/postgresql-dbpatch) (v1.2.0+)
  - [`linz_bde_uploader`](https://github.com/linz/linz-bde-uploader) (v2.4.0+)

--- a/debian/control
+++ b/debian/control
@@ -14,6 +14,6 @@ Depends: ${misc:Depends},
          tableversion,
          dbpatch,
          linz-bde-uploader (>= 2.4.0),
-         linz-bde-schema
+         linz-bde-schema (>= 1.11.0)
 Description: Provides the schemas and functions to generate the Landonline
  layers and tables that are available on the LDS.


### PR DESCRIPTION
This is needed for simplified layers function to work, as it
references tables which are only available with linz-bde-schema
1.11.0 or higher.