### PR TITLE
[ci] Do not build packages on pushing tags ending with "start"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on:
       - 'release-*'
     tags-ignore:
       - 'debian/*'
+      - '*-start'
   pull_request:
     branches:
       - '*'


### PR DESCRIPTION
This is to allow defining tags on the first commit in master branch
after a new stable branch is created. The tag would look like
"1.12-start", so that `git describe` produces a version which is,
according to dpkg --compare-version, *newer* than any version coming
out from the most recent stable branch while still being *older*
than the final .0 version being targetted in master branch (ie:
1.12.0)