### PR TITLE
fix: check crs_ttl_inst_protect table when launching FBDE maintenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ this file.
 
 ## 1.11.3dev - YYYY-MM-DD
 ### Fixed
-- ...
+- Have changes in `crs_ttl_inst_protect` trigger FBDE maintenance (#244)
 
 ## 1.11.2 - 2020-08-25
 ### Fixed

--- a/sql/06-bde_ext_functions.sql.in
+++ b/sql/06-bde_ext_functions.sql.in
@@ -134,6 +134,7 @@ BEGIN
                     'crs_ttl_hierarchy',
                     'crs_ttl_inst',
                     'crs_ttl_inst_title',
+                    'crs_ttl_inst_protect',
                     'crs_user',
                     'crs_vector',
                     'crs_work',


### PR DESCRIPTION
Closes #244 in 1.11 branch